### PR TITLE
New model for ion-neutral collisions

### DIFF
--- a/src/pic2d_MainProgram.f90
+++ b/src/pic2d_MainProgram.f90
@@ -345,7 +345,8 @@ PROGRAM MainProg
 
         CALL MPI_BARRIER(MPI_COMM_WORLD, ierr) 
 
-        CALL PERFORM_RESONANT_CHARGE_EXCHANGE    ! the only ion-neutral collision kind for now, does not produce new ions
+        CALL PERFORM_RESONANT_CHARGE_EXCHANGE ! old ion-neutral collision model for resonant charge exchange only
+        CALL PERFORM_ION_NEUTRAL_COLLISION ! new ion-neutral collision model
 
         CALL MPI_BARRIER(MPI_COMM_WORLD, ierr) 
 

--- a/src/pic2d_Modules.f90
+++ b/src/pic2d_Modules.f90
@@ -1160,7 +1160,7 @@ MODULE MCCollisions
 
   LOGICAL en_collisions_turned_off
   LOGICAL no_ionization_collisions
-  LOGICAL no_rcx_collisions
+  LOGICAL no_in_collisions
 
   INTEGER N_neutral_spec
 
@@ -1191,6 +1191,11 @@ MODULE MCCollisions
      integer rcx_ion_species_index
      real(8) sigma_rcx_m2_1eV
      real(8) alpha_rcx
+     logical in_cols_on ! switch ion-neutral collisions on/off
+     real(8) alpha ! polarizability of neutral (in units of Angstrom^3)
+     real(8) beta_inf ! cutoff for impact parameter of ion-neutral collisions, lower for speed, raise for accuracy
+     real(8) Axc ! resonant charge exchange parameter (determine by comparison with swarm experiments)
+     real(8), ALLOCATABLE :: Fel_precalc(:) ! careful when changing size!
   END TYPE neutral_type
 
   TYPE(neutral_type), ALLOCATABLE :: neutral(:)

--- a/src/pic2d_inCollisionsSpecificProc.f90
+++ b/src/pic2d_inCollisionsSpecificProc.f90
@@ -14,11 +14,12 @@ subroutine calculate_thermal_cx_probab
 !function
   real(8) sigma_rcx_m2
 
-  if (no_rcx_collisions) return
+  if (no_in_collisions) return
 
   DO s = 1, N_spec
      if (.not.collision_rcx(s)%rcx_on) cycle
      n = collision_rcx(s)%neutral_species_index
+     if (neutral(n)%in_cols_on) cycle ! skip if we use the new in-col model
      sigma_m2_1eV = neutral(n)%sigma_rcx_m2_1eV
      alpha = neutral(n)%alpha_rcx
      Tgas_eV = neutral(n)%T_K * kB_JK / e_Cl
@@ -70,7 +71,7 @@ subroutine PERFORM_RESONANT_CHARGE_EXCHANGE
 ! functions
   real(8) neutral_density_normalized, sigma_rcx_m2
   
-  if (no_rcx_collisions) return
+  if (no_in_collisions) return
 
 ! clear collision counters
   DO s = 1, N_spec
@@ -82,6 +83,7 @@ subroutine PERFORM_RESONANT_CHARGE_EXCHANGE
      if (.not.collision_rcx(s)%rcx_on) cycle
 
      n = collision_rcx(s)%neutral_species_index
+     if (neutral(n)%in_cols_on) cycle ! skip if we use the new in-col model
 
      ngas_m3 = neutral(n)%N_m3
      sigma_m2_1eV = neutral(n)%sigma_rcx_m2_1eV
@@ -94,7 +96,6 @@ subroutine PERFORM_RESONANT_CHARGE_EXCHANGE
 
      DO i = 1, N_ions(s)
 
-!        if (well_random_number().GT.neutral_density_normalized(n, ion(s)%part(i)%x, ion(s)%part(i)%y)) cycle   ! for uniform density profile this is not necessary
 
         vx = ion(s)%part(i)%VX
         vy = ion(s)%part(i)%VY
@@ -103,9 +104,7 @@ subroutine PERFORM_RESONANT_CHARGE_EXCHANGE
         energy_eV = vsq * factor_eV
         vabs_ms = sqrt(vsq) * V_scale_ms 
 
-!        probab_rcx = ngas_m3 * vabs_ms * sigma_rcx_m2(energy_eV, sigma_m2_1eV, alpha) * delta_t_s * N_subcycles
         probab_rcx = prob_factor * vabs_ms * sigma_rcx_m2(energy_eV, sigma_m2_1eV, alpha)
-
         probab_rcx = neutral_density_normalized(n, ion(s)%part(i)%x, ion(s)%part(i)%y) * sqrt(probab_rcx**2 + probab_rcx_therm_2)  ! account for the nonuniform density and the low-energy correction
 
         if (well_random_number().le.probab_rcx) then
@@ -124,3 +123,194 @@ subroutine PERFORM_RESONANT_CHARGE_EXCHANGE
   END DO   
 
 END SUBROUTINE PERFORM_RESONANT_CHARGE_EXCHANGE
+
+
+
+SUBROUTINE PERFORM_ION_NEUTRAL_COLLISION
+  ! Julian Held, j.held@tue.nl, 2025
+  ! After: Nanbu and Kitatani: J. Phys. D: Appl. Phys. 28 (1995) 324-330
+  
+    USE MCCollisions
+    USE IonParticles
+    USE CurrentProblemValues, ONLY : energy_factor_eV, delta_t_s, N_subcycles, V_scale_ms, T_cntr, pi, e_Cl, true_eps_0_Fm, amu_kg, kB_JK, T_e_eV, N_max_vel
+    USE rng_wrapper
+    !use stdlib_specialfunctions_gamma, only: gamma
+  
+    IMPLICIT NONE
+    INCLUDE 'mpif.h'
+  
+  
+    INTEGER s, n, i
+    INTEGER ierr
+    LOGICAL CX ! did charge exchange occur?
+    real(8) vfactor, ngas_m3
+  
+    real(8) vx, vy, vz, vx_, vy_, vz_, Ekin, vr_ms
+    real(8) vxn, vyn, vzn, vxn_, vyn_, vzn_ ! neutral velocities before and after
+    real(8) Rx, Ry, Rz
+    real(8) gx, gy, gz, g, g_perp, hx, hy, hz
+    real(8) Mi, Mn
+    real(8) E_ratio, E_ratio_ion
+  
+    real(8) neutral_density_normalized ! function
+  
+    real(8) beta_inf, alpha0, q, mr, beta_cx
+    real(8) sigmaL, sigmaP, sigmaT, sigma_cx, d0, a, Acx
+    real(8) p_col, bmax_col, bmax_cx, bmax, b
+    real(8) xi0, xi1, xi, chi, beta, beta0, theta, theta0, Fel, dtheta
+    real(8) cos_chi, sin_chi, phi
+  
+    beta0 = 1.001 ! beta > beta0 -> spiraling 
+
+    if (no_in_collisions) return
+
+    ! clear collision counters
+    DO s = 1, N_spec
+        collision_rcx(s)%counter = 0
+    END DO
+
+    DO s = 1, N_spec
+      DO n = 1, N_neutral_spec
+        if (.not.neutral(n)%in_cols_on) cycle
+
+        ngas_m3 = neutral(n)%N_m3
+        beta_inf = neutral(n)%beta_inf ! beta_inf may be lowered for slow ions or small E/N to allow for larger timesteps
+        alpha0 = neutral(n)%alpha * 1D-30 ! polarizability of neutral
+        Acx = neutral(n)%Axc ! resonant charge exchange parameter (check for same species later)
+        Mn = neutral(n)%M_amu * amu_kg
+        vfactor = SQRT(neutral(n)%T_K * kB_JK / (T_e_eV * e_Cl * Ms(s))) / DBLE(N_max_vel) 
+
+        q = Qs(s) * e_Cl 
+        Mi = M_i_amu(s) * amu_kg
+        mr = Mi*Mn/(Mi+Mn) 
+    
+        DO i = 1, N_ions(s)
+          CX = .False.
+          a = alpha0 * (q**2) / (2.0*(4.0*pi*true_eps_0_Fm))
+          p_col = ngas_m3 * sqrt(8.0*a/mr) * pi * (beta_inf**2) * delta_t_s * N_subcycles * neutral_density_normalized(n, ion(s)%part(i)%x, ion(s)%part(i)%y)
+    
+          if (well_random_number().le.p_col) then ! perform collision
+            collision_rcx(s)%counter = collision_rcx(s)%counter + 1
+            beta = beta_inf * sqrt(well_random_number())
+            beta_cx = Acx * (Ekin/e_Cl)**(0.25)
+    
+            ! create a virtual neutral particle
+            call GetMaxwellVelocity(vxn)
+            call GetMaxwellVelocity(vyn)
+            call GetMaxwellVelocity(vzn)
+            vxn = vxn * vfactor * V_scale_ms
+            vyn = vyn * vfactor * V_scale_ms
+            vzn = vzn * vfactor * V_scale_ms
+      
+            vx = ion(s)%part(i)%VX * V_scale_ms
+            vy = ion(s)%part(i)%VY * V_scale_ms
+            vz = ion(s)%part(i)%VZ * V_scale_ms
+      
+            ! relative velocity between colliding particles
+            gx = vxn-vx
+            gy = vyn-vy
+            gz = vzn-vz
+            g = sqrt((gx)**2 + (gy)**2 + (gz)**2)
+            g_perp = sqrt(gy**2 + gz**2)
+    
+            Ekin = 0.5 * mr * g**2
+    
+            phi = 2.0*pi*well_random_number()
+            hx = g_perp * cos(phi)
+            hy = -(gy*gx*cos(phi) + g*gz*sin(phi)) / g_perp                                                
+            hz = -(gz*gx*cos(phi) - g*gy*sin(phi)) / g_perp
+    
+            if (beta.GE.beta0) then ! beta > 1 ->  polarization scattering and maybe CX
+              xi0 = sqrt(beta**2 - sqrt(beta**4 - 1))
+              xi1 = sqrt(beta**2 + sqrt(beta**4 - 1))
+              xi = xi0/xi1
+    
+              ! find scattering angle chi
+              if (beta.LE.3) then
+                Fel = neutral(n)%Fel_precalc( nint(xi*(50000.0-1.0)) )
+                theta0 = sqrt(2.0)*beta/xi1 * Fel
+                chi = pi - 2.0 * theta0
+              else
+                chi = -(3.0*pi/16.0)*beta**(-4)
+              end if
+    
+              cos_chi = cos(chi)
+              sin_chi = abs(sin(chi))
+              
+              ! post-collision velocities
+              vx_ =  vx +  Mn/(Mi + Mn) * (gx*(1-cos_chi) + hx*sin_chi)
+              vy_ =  vy +  Mn/(Mi + Mn) * (gy*(1-cos_chi) + hy*sin_chi)
+              vz_ =  vz +  Mn/(Mi + Mn) * (gz*(1-cos_chi) + hz*sin_chi)
+              vxn_ = vxn - Mi/(Mi + Mn) * (gx*(1-cos_chi) + hx*sin_chi)
+              vyn_ = vyn - Mi/(Mi + Mn) * (gy*(1-cos_chi) + hy*sin_chi)
+              vzn_ = vzn - Mi/(Mi + Mn) * (gz*(1-cos_chi) + hz*sin_chi)
+      
+              ! CX: identity switch (50% chance if beta < beta_cx)
+              if ((well_random_number().le.0.5).AND.(beta.LE.beta_cx)) then  
+                CX = .True.
+              end if
+    
+            end if  
+    
+    
+            if (beta.LT.beta0) then ! spiraling motion, VHS (variable hard sphere) model
+              
+              ! VHS model -> random direction
+              theta = acos(1.0 - 2.0*well_random_number())
+              phi = 2.0*pi*well_random_number()
+              Rx = cos(theta)
+              Ry = sin(theta) * cos(phi)
+              Rz = sin(theta) * sin(phi)
+              
+              ! post-collision velocities
+              vx_ =  (1/(Mi + Mn)) * (Mi*vx + Mn*vxn - Mn*g*Rx)
+              vy_ =  (1/(Mi + Mn)) * (Mi*vy + Mn*vyn - Mn*g*Ry)
+              vz_ =  (1/(Mi + Mn)) * (Mi*vz + Mn*vzn - Mn*g*Rz)
+              vxn_ = (1/(Mi + Mn)) * (Mi*vx + Mn*vxn + Mi*g*Rx)
+              vyn_ = (1/(Mi + Mn)) * (Mi*vy + Mn*vyn + Mi*g*Ry)
+              vzn_ = (1/(Mi + Mn)) * (Mi*vz + Mn*vzn + Mi*g*Rz)
+    
+              if (well_random_number().le.0.5) then ! CX: (50% chance when spiraling)
+                CX = .TRUE.
+              end if 
+
+            end if
+            
+            ! check if ion and neutral species are the same (via mass)
+            ! if not, disable charge exchange after all (ignoring the non-resonant case)
+            if (ABS(Mn-Mi).GT.0.1) then
+              CX = .FALSE.
+            end if
+
+            if (CX) then ! assign neutral post-collision velcoity to the ion (col + identity switch)
+              ion(s)%part(i)%VX = vxn_/V_scale_ms
+              ion(s)%part(i)%VY = vyn_/V_scale_ms
+              ion(s)%part(i)%VZ = vzn_/V_scale_ms
+            else ! assign ion post-collision velocity (no identity switch)
+              ion(s)%part(i)%VX = vx_/V_scale_ms
+              ion(s)%part(i)%VY = vy_/V_scale_ms
+              ion(s)%part(i)%VZ = vz_/V_scale_ms
+            end if
+    
+            ! Check for energy conservation. 
+            E_ratio = (0.5*Mi*(vx_**2+vy_**2+vz_**2) + 0.5*Mn*(vxn_**2 + vyn_**2 + vzn_**2))/(0.5*Mi*(vx**2+vy**2+vz**2) + 0.5*Mn*(vxn**2 + vyn**2 + vzn**2))
+            E_ratio_ion = (0.5*Mi*(vx_**2+vy_**2+vz_**2))/(0.5*Mi*(vx**2+vy**2+vz**2))
+            if ((E_ratio-1.0).GT.1E-6) then
+              PRINT *, "Error in PERFORM_ION_NEUTRAL_COLLISION. Energy not conserved. This should never happen. Energy lost (1-E_before/E_after): ", (1-E_ratio)
+              PRINT *, "Beta: ", beta  
+              PRINT *, "Charge exchange occured?: ", CX  
+              CALL MPI_ABORT(MPI_COMM_WORLD, ierr)
+            end if
+    
+            ! check if collision frequency is okay
+            if (p_col.GT.0.5) then
+              PRINT *, "Error in PERFORM_ION_NEUTRAL_COLLISION. Collision rate too high. Need to use smaller time steps. Collision probability was p_col =  ", p_col
+              CALL MPI_ABORT(MPI_COMM_WORLD, ierr)
+            end if
+    
+          end if ! if col
+        END DO ! ion loop
+      END DO ! neutral species loop
+    END DO ! ion species loop
+  
+  END SUBROUTINE PERFORM_ION_NEUTRAL_COLLISION

--- a/src/pic2d_inCollisionsSpecificProc.f90
+++ b/src/pic2d_inCollisionsSpecificProc.f90
@@ -278,7 +278,7 @@ SUBROUTINE PERFORM_ION_NEUTRAL_COLLISION
             
             ! check if ion and neutral species are the same (via mass)
             ! if not, disable charge exchange after all (ignoring the non-resonant case)
-            if (ABS(Mn-Mi).GT.0.1) then
+            if (ABS((Mn-Mi)/Mn).GT.0.01) then
               CX = .FALSE.
             end if
 


### PR DESCRIPTION
Hi Willca,

I finally managed to bring the new ion-neutral collision model to a place where it can reasonably be used by other people. I'll use the space here to write down my thoughts behind the implementation and how it is configured.

The implementation faithfully follows the model of Nanbu and Kitatani: J. Phys. D: Appl. Phys. 28 (1995) 324-330 without any adjustments.

The idea was to allow this to be pulled into your branch without affecting existing users. As such, the old collision model remains and will be used unless a new configuration option is detected. Unless this configuration option is found, this pull request should cause no change whatsoever to how the simulation is performed.

## Configuration

I decided to add the configuration options to `init_neutral_AAAAAA.dat`. This was done for two reasons:
- The old collision model already reads the ion mass from the file, so we were requiring this file already for ion-neutral collisions.
- In the new model, the collisions are entirely described by the properties of the neutral species, so this seems like the natural place to put it. 

Example config file (added .txt since github does not like the .dat ending): [init_neutral_Argon0.dat.txt](https://github.com/user-attachments/files/18453610/init_neutral_Argon0.dat.txt)

The relevant lines are at the end:
```
----d------------------------ Enable ion-neutral collisions?
    1
--dd.d--d.dd--dd.ddddd---- beta_inf / A / polarizability (in units of Angstrom^3)
   9.0  2.60   1.64110
```
The three parameters are:
- beta_inf: Defines the impact parameter cutoff. Larger values lead to more accuracy, especially for large values of E/N (e.g. in the sheath or during ignition) while smaller values reduce the frequency of small angle collisions and, thus, increase performance. The value of 9 should work under most circumstances. The parameter is independent of species in might never need to be changed. 
- A: Parameter for the resonant charge-exchange cross-section. Can be obtained from the comparison between simulation and swarm experiments, found in the literature for many species, or might possibly be calculated from charge-exchange cross sections. Values from the original paper: Ar: 2.6, Ne: 2.6, He: 2.6, Kr: 2.5.
- Polarizability: Can be found tabulated for basically any atom/molecule. Mind the units. 

The user is informed if the new model is activated by the configuration: `### file ",A23," enables ion-neutral collisions for neutral species ",i2," (",A6,"). The new collision model will be used. ###`.

In the code, the neutral species flag `neutral(n)%in_cols_on` is used to track whether the new ion-neutral collisions are done per neutral species.

To make sure there is no crash when the config is missing, the code checks whether there are more lines in the file and if so, whether the line starts with `-` and only then assumes the next three lines to be well-formatted according to the expectations. See lines 147 to 158 in `pic2d_enCollisionsGeneralProc` for the implementation.

## Interaction with the old ion-neutral collision model

Since the old model remains and the new one is only activated if a user explicitly adds the above-described config lines, the new model overwrites the old one if both are activated. The user is informed as such: `### Both the old model for RCX as well as the new one for polarization scattering + RCX are switched on. Only the new model will be used. ###`.

We keep using the existing code paths for the collision counter and for setting that up. Adjustments were made to ensure that the counter is correctly setup if either of the two collision models is active for any species.

I wasn't really planning this, but as a byproduct of both the old and the new model being entirely performed and configured on a per-species basis, we can even mix both models, e.g. it should be possible to have Ion-Helium collisions with the new model and Ion-Argon collisions with the old one, within the same simulation run. I haven't tested that, however.  

## Capabilities
What follows is a random list of things I have considered and that are possible with the code (and whether I performed tests). Please take a look and see if anything is missing here that needs to be considered.

- Inhomogeneous neutral density using neutral_density_normalized(n, ion(s)%part(i)%x, ion(s)%part(i)%y) (untested, but seems hard to mess up).
- Multiple ion species: If the ion mass is equal, we use the full model with resonant charge exchange. If not, we only do polarization scattering. (untested)
- Multiple neutral species: configuration is done on a per-species basis using the species density (untested)
- Collision-frequency checking: If the density is too high, the collision time can become smaller than the timestep, which will artificially lower the collisionality. We handle this by checking for the collision probability and throwing an error if it is larger than 0.5. (tested) 

## Performance Impact
We do a lot more calculations with the new model compared to the old one and need to loop over every single ion, sometimes multiple times (once per neutral species). However, the performance impact is limited by the fact that we only do this in the ion-move step. Previously, we numerically solved an integral for the collision angle for every collision, which is now pre-calculated. Even then, the performance impact was not very noticeable. Compared to the other very costly things that we are doing during the ion-move step, the impact seems to not be noticeable. 

## Testing
As you know, the model implementation itself is benchmarked. Since the changes to the actual subroutine since then have been minor, I have not repeated the benchmark (it's a lot of work). I did ensure that the model correctly switches on and off depending on the configuration, that the subroutine is reached and that the parameters from the config are correctly loaded and applied. 

I will repeat one of my previous simulation runs with the new code to ensure that really nothing changed within the main subroutine. I'll leave the more complex test cases to you.